### PR TITLE
feat: Rethrow original exception in kotlin invisible calls

### DIFF
--- a/catadioptre-java/src/main/java/io/aerisconsulting/catadioptre/CatadioptreOriginalCauseException.java
+++ b/catadioptre-java/src/main/java/io/aerisconsulting/catadioptre/CatadioptreOriginalCauseException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 AERIS-Consulting e.U.
+ *
+ * AERIS-Consulting e.U. licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.aerisconsulting.catadioptre;
+
+/**
+ * Catadioptre exception that encapsulates checked and unchecked exceptions thrown when invoking original methods.
+ *
+ * @author Gabriel Moraes
+ */
+public class CatadioptreOriginalCauseException extends RuntimeException {
+
+	public CatadioptreOriginalCauseException(final Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/catadioptre-java/src/main/java/io/aerisconsulting/catadioptre/ReflectionMethodUtils.java
+++ b/catadioptre-java/src/main/java/io/aerisconsulting/catadioptre/ReflectionMethodUtils.java
@@ -53,9 +53,9 @@ public class ReflectionMethodUtils {
 	 * Executes a method that cannot be accessible in the caller scope.
 	 *
 	 * @param instance the instance for the "this" of the executed method
-	 * @param name the name of the method to execute
-	 * @param value the arguments to pass to the method, which can be eiter
-	 * @param <T> the type of the result
+	 * @param name     the name of the method to execute
+	 * @param value    the arguments to pass to the method, which can be eiter
+	 * @param <T>      the type of the result
 	 * @return the result of the execution of the method {@code name} on {@code instance}
 	 */
 	public static <T> T executeInvisible(Object instance, String name, Object... value) {
@@ -79,7 +79,9 @@ public class ReflectionMethodUtils {
 		try {
 			//noinspection unchecked
 			return (T) method.invoke(instance, argumentsValues.toArray());
-		} catch (InvocationTargetException | IllegalAccessException e) {
+		} catch (InvocationTargetException e) {
+			throw new CatadioptreOriginalCauseException(e.getCause());
+		} catch (Exception e) {
 			throw new CatadioptreException(e);
 		}
 	}
@@ -106,8 +108,7 @@ public class ReflectionMethodUtils {
 	}
 
 	/**
-	 * Determines if each parameter type of a method, is either the class or a superclass or superinterface of the type
-	 * of the argument with the same index.
+	 * Determines if each parameter type of a method, is either the class or a superclass or superinterface of the type of the argument with the same index.
 	 */
 	private static boolean areArgumentsAssignable(Class<?>[] parameterTypes, Argument[] argumentDefinitions) {
 		if (parameterTypes.length != argumentDefinitions.length) {

--- a/catadioptre-java/src/test/java/io/aerisconsulting/catadioptre/ReflectionMethodUtilsTest.java
+++ b/catadioptre-java/src/test/java/io/aerisconsulting/catadioptre/ReflectionMethodUtilsTest.java
@@ -118,4 +118,17 @@ class ReflectionMethodUtilsTest {
 		// then
 		Assertions.assertEquals(5.0, result);
 	}
+
+	@Test
+	void shouldThrowOriginalCauseOfException() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+		// given
+		final ReflectionUtilsObject object = new ReflectionUtilsObject();
+
+		// when
+		Throwable cause = Assertions.assertThrows(CatadioptreOriginalCauseException.class, () ->
+				ReflectionMethodUtils.executeInvisible(object, "throwException")
+		);
+
+		Assertions.assertEquals(RuntimeException.class, cause.getCause().getClass());
+	}
 }

--- a/catadioptre-java/src/test/java/io/aerisconsulting/catadioptre/ReflectionUtilsObject.java
+++ b/catadioptre-java/src/test/java/io/aerisconsulting/catadioptre/ReflectionUtilsObject.java
@@ -31,4 +31,8 @@ public class ReflectionUtilsObject extends ParentReflectionUtilsObject {
 	private double divideSum(int divider, List<Integer> values) {
 		return values.stream().filter(Objects::nonNull).mapToInt(i -> i).sum() / divider;
 	}
+
+	private void throwException() {
+		throw new RuntimeException("");
+	}
 }

--- a/catadioptre-kotlin/src/main/kotlin/io/aerisconsulting/catadioptre/CatadioptreOriginalCauseException.kt
+++ b/catadioptre-kotlin/src/main/kotlin/io/aerisconsulting/catadioptre/CatadioptreOriginalCauseException.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 AERIS-Consulting e.U.
+ *
+ * AERIS-Consulting e.U. licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.aerisconsulting.catadioptre
+
+/**
+ * Catadioptre exception that encapsulates checked and unchecked exceptions thrown when invoking original methods.
+ *
+ * @author Gabriel Moraes
+ */
+class CatadioptreOriginalCauseException(cause: Throwable?) : RuntimeException(cause)

--- a/catadioptre-kotlin/src/main/kotlin/io/aerisconsulting/catadioptre/DynamicCall.kt
+++ b/catadioptre-kotlin/src/main/kotlin/io/aerisconsulting/catadioptre/DynamicCall.kt
@@ -14,6 +14,7 @@
  */
 package io.aerisconsulting.catadioptre
 
+import java.lang.reflect.InvocationTargetException
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
@@ -39,7 +40,11 @@ internal class DynamicCall<T>(
         val function = findFunction(instance::class, functionName, arguments.map(Argument::type))
         return if (function != null) {
             val allArguments = prepareFunction(function)
-            function.callBy(allArguments) as T
+            try {
+                function.callBy(allArguments) as T
+            } catch (targetException: InvocationTargetException) {
+                throw targetException.cause!!
+            }
         } else {
             throw IllegalArgumentException("The function $functionName could not be found for the arguments $arguments")
         }
@@ -59,7 +64,11 @@ internal class DynamicCall<T>(
         val function = findFunction(instance::class, functionName, arguments.map(Argument::type))
         return if (function != null) {
             val allArguments = prepareFunction(function)
-            function.callSuspendBy(allArguments) as T
+            try {
+                function.callSuspendBy(allArguments) as T
+            } catch (targetException: InvocationTargetException) {
+                throw targetException.cause!!
+            }
         } else {
             throw IllegalArgumentException("The function $functionName could not be found for the arguments $arguments")
         }

--- a/catadioptre-kotlin/src/main/kotlin/io/aerisconsulting/catadioptre/DynamicCall.kt
+++ b/catadioptre-kotlin/src/main/kotlin/io/aerisconsulting/catadioptre/DynamicCall.kt
@@ -43,7 +43,7 @@ internal class DynamicCall<T>(
             try {
                 function.callBy(allArguments) as T
             } catch (targetException: InvocationTargetException) {
-                throw targetException.cause!!
+                throw CatadioptreOriginalCauseException(targetException.cause!!)
             }
         } else {
             throw IllegalArgumentException("The function $functionName could not be found for the arguments $arguments")
@@ -67,7 +67,7 @@ internal class DynamicCall<T>(
             try {
                 function.callSuspendBy(allArguments) as T
             } catch (targetException: InvocationTargetException) {
-                throw targetException.cause!!
+                throw CatadioptreOriginalCauseException(targetException.cause!!)
             }
         } else {
             throw IllegalArgumentException("The function $functionName could not be found for the arguments $arguments")

--- a/catadioptre-kotlin/src/test/kotlin/io/aerisconsulting/catadioptre/ClassesWithInvisibleMembers.kt
+++ b/catadioptre-kotlin/src/test/kotlin/io/aerisconsulting/catadioptre/ClassesWithInvisibleMembers.kt
@@ -35,6 +35,8 @@ class ReflectionUtilsObject(
         return values.filterNotNull().sum() / divider
     }
 
+    private fun throwException(): Nothing = throw RuntimeException("")
+
 }
 
 @Suppress("RedundantSuspendModifier")
@@ -49,6 +51,9 @@ open class SuspendedParentReflectionUtilsObject(
     private suspend fun inheritedDivide(value: Number = 10, divider: Int) = value.toInt() / divider
 
     private suspend fun inheritedDivideSum(divider: Int = 1, vararg values: Int) = values.sum() / divider
+
+
+    private fun throwExceptionSuspended(): Nothing = throw RuntimeException("")
 
 }
 

--- a/catadioptre-kotlin/src/test/kotlin/io/aerisconsulting/catadioptre/ClassesWithInvisibleMembers.kt
+++ b/catadioptre-kotlin/src/test/kotlin/io/aerisconsulting/catadioptre/ClassesWithInvisibleMembers.kt
@@ -52,8 +52,7 @@ open class SuspendedParentReflectionUtilsObject(
 
     private suspend fun inheritedDivideSum(divider: Int = 1, vararg values: Int) = values.sum() / divider
 
-
-    private fun throwExceptionSuspended(): Nothing = throw RuntimeException("")
+    private suspend fun throwExceptionSuspended(): Nothing = throw RuntimeException("")
 
 }
 

--- a/catadioptre-kotlin/src/test/kotlin/io/aerisconsulting/catadioptre/ReflectionFunctionUtilsTest.kt
+++ b/catadioptre-kotlin/src/test/kotlin/io/aerisconsulting/catadioptre/ReflectionFunctionUtilsTest.kt
@@ -16,7 +16,9 @@ package io.aerisconsulting.catadioptre
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isIn
 import assertk.assertions.isNull
+import assertk.assertions.isSameAs
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -174,9 +176,11 @@ internal class ReflectionFunctionUtilsTest {
         val instance = ReflectionUtilsObject()
 
         // when
-        assertThrows<RuntimeException> {
+        val cause = assertThrows<CatadioptreOriginalCauseException> {
             instance.invokeInvisible("throwException")
-        }
+        }.cause
+
+        assertThat(cause?.javaClass).isEqualTo(java.lang.RuntimeException::class.java)
     }
 
     @Test
@@ -292,7 +296,7 @@ internal class ReflectionFunctionUtilsTest {
     @Test
     internal fun `should execute an inherited suspended function with omitted argument`() = runBlockingTest {
         // given
-        val instance = ReflectionUtilsObject()
+        val instance = SuspendedReflectionUtilsObject()
 
         // when
         val value: Int = instance.coInvokeInvisible("returnInheritedProvidedOrValue", omitted<Int>())
@@ -304,7 +308,7 @@ internal class ReflectionFunctionUtilsTest {
     @Test
     internal fun `should execute an inherited suspended function with all indexed arguments`() = runBlockingTest {
         // given
-        val instance = ReflectionUtilsObject()
+        val instance = SuspendedReflectionUtilsObject()
 
         // when
         val value: Int = instance.coInvokeInvisible("inheritedDivide", 12, 6)
@@ -316,7 +320,7 @@ internal class ReflectionFunctionUtilsTest {
     @Test
     internal fun `should execute an inherited suspended function with an argument and vararg`() = runBlockingTest {
         // given
-        val instance = ReflectionUtilsObject()
+        val instance = SuspendedReflectionUtilsObject()
 
         // when
         val value: Int = instance.coInvokeInvisible("inheritedDivideSum", 2, vararg(1, 3, 6))
@@ -328,12 +332,13 @@ internal class ReflectionFunctionUtilsTest {
     @Test
     internal fun `should throw original exception when executing suspended function`() = runBlockingTest {
         // given
-        val instance = ReflectionUtilsObject()
+        val instance = SuspendedReflectionUtilsObject()
 
         // when
-        assertThrows<RuntimeException> {
+        val cause = assertThrows<CatadioptreOriginalCauseException> {
             instance.coInvokeInvisible("throwExceptionSuspended")
-        }
+        }.cause
+        assertThat(cause?.javaClass).isEqualTo(java.lang.RuntimeException::class.java)
     }
 
 }

--- a/catadioptre-kotlin/src/test/kotlin/io/aerisconsulting/catadioptre/ReflectionFunctionUtilsTest.kt
+++ b/catadioptre-kotlin/src/test/kotlin/io/aerisconsulting/catadioptre/ReflectionFunctionUtilsTest.kt
@@ -19,6 +19,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 internal class ReflectionFunctionUtilsTest {
 
@@ -168,6 +169,17 @@ internal class ReflectionFunctionUtilsTest {
     }
 
     @Test
+    internal fun `should throw original exception when executing function`() {
+        // given
+        val instance = ReflectionUtilsObject()
+
+        // when
+        assertThrows<RuntimeException> {
+            instance.invokeInvisible("throwException")
+        }
+    }
+
+    @Test
     internal fun `should execute a private suspended function without argument`() = runBlockingTest {
         // given
         val instance = SuspendedReflectionUtilsObject()
@@ -311,6 +323,17 @@ internal class ReflectionFunctionUtilsTest {
 
         // then
         assertThat(value).isEqualTo(5)
+    }
+
+    @Test
+    internal fun `should throw original exception when executing suspended function`() = runBlockingTest {
+        // given
+        val instance = ReflectionUtilsObject()
+
+        // when
+        assertThrows<RuntimeException> {
+            instance.coInvokeInvisible("throwExceptionSuspended")
+        }
     }
 
 }

--- a/examples/catadioptre-java-gradle-groovy-dsl-example/src/main/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExample.java
+++ b/examples/catadioptre-java-gradle-groovy-dsl-example/src/main/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExample.java
@@ -8,5 +8,9 @@ class DefaultCatadioptreExample {
 	private String toLowerCase(String text) {
 		return text.toLowerCase();
 	}
-	
+
+	@Testable
+	private String callMethodThrowingException(String example) {
+		throw new IllegalStateException(example);
+	}
 }

--- a/examples/catadioptre-java-gradle-groovy-dsl-example/src/test/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExampleTest.java
+++ b/examples/catadioptre-java-gradle-groovy-dsl-example/src/test/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExampleTest.java
@@ -1,5 +1,6 @@
 package io.aerisconsulting.catadioptre.example;
 
+import io.aerisconsulting.catadioptre.CatadioptreOriginalCauseException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,8 +20,8 @@ class DefaultCatadioptreExampleTest {
 	void shouldThrowSameExceptionRealMethod() {
 		DefaultCatadioptreExample instance = new DefaultCatadioptreExample();
 
-		Assertions.assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
+		Assertions.assertThatExceptionOfType(CatadioptreOriginalCauseException.class).isThrownBy( () -> {
 			TestableDefaultCatadioptreExample.callMethodThrowingException(instance, "test");
-		});
+		}).withCauseInstanceOf(IllegalStateException.class);
 	}
 }

--- a/examples/catadioptre-java-gradle-groovy-dsl-example/src/test/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExampleTest.java
+++ b/examples/catadioptre-java-gradle-groovy-dsl-example/src/test/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExampleTest.java
@@ -13,4 +13,14 @@ class DefaultCatadioptreExampleTest {
 		String result = TestableDefaultCatadioptreExample.toLowerCase(instance, "T");
 		Assertions.assertThat(result).isEqualTo("t");
 	}
+
+	@Test
+	@DisplayName("should throw the same exception that the real method")
+	void shouldThrowSameExceptionRealMethod() {
+		DefaultCatadioptreExample instance = new DefaultCatadioptreExample();
+
+		Assertions.assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
+			TestableDefaultCatadioptreExample.callMethodThrowingException(instance, "test");
+		});
+	}
 }

--- a/examples/catadioptre-java-gradle-kotlin-dsl-example/src/main/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExample.java
+++ b/examples/catadioptre-java-gradle-kotlin-dsl-example/src/main/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExample.java
@@ -8,5 +8,9 @@ class DefaultCatadioptreExample {
 	private String toLowerCase(String text) {
 		return text.toLowerCase();
 	}
-	
+
+	@Testable
+	private String callMethodThrowingException(String example) {
+		throw new IllegalStateException(example);
+	}
 }

--- a/examples/catadioptre-java-gradle-kotlin-dsl-example/src/test/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExampleTest.java
+++ b/examples/catadioptre-java-gradle-kotlin-dsl-example/src/test/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExampleTest.java
@@ -13,4 +13,14 @@ class DefaultCatadioptreExampleTest {
 		String result = TestableDefaultCatadioptreExample.toLowerCase(instance, "T");
 		Assertions.assertThat(result).isEqualTo("t");
 	}
+
+	@Test
+	@DisplayName("should throw the same exception that the real method")
+	void shouldThrowSameExceptionRealMethod() {
+		DefaultCatadioptreExample instance = new DefaultCatadioptreExample();
+
+		Assertions.assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
+			TestableDefaultCatadioptreExample.callMethodThrowingException(instance, "test");
+		});
+	}
 }

--- a/examples/catadioptre-java-gradle-kotlin-dsl-example/src/test/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExampleTest.java
+++ b/examples/catadioptre-java-gradle-kotlin-dsl-example/src/test/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExampleTest.java
@@ -1,5 +1,6 @@
 package io.aerisconsulting.catadioptre.example;
 
+import io.aerisconsulting.catadioptre.CatadioptreOriginalCauseException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,8 +20,8 @@ class DefaultCatadioptreExampleTest {
 	void shouldThrowSameExceptionRealMethod() {
 		DefaultCatadioptreExample instance = new DefaultCatadioptreExample();
 
-		Assertions.assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
+		Assertions.assertThatExceptionOfType(CatadioptreOriginalCauseException.class).isThrownBy(() -> {
 			TestableDefaultCatadioptreExample.callMethodThrowingException(instance, "test");
-		});
+		}).withCauseInstanceOf(IllegalStateException.class);
 	}
 }

--- a/examples/catadioptre-java-maven-example/src/main/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExample.java
+++ b/examples/catadioptre-java-maven-example/src/main/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExample.java
@@ -8,5 +8,9 @@ class DefaultCatadioptreExample {
 	private String toLowerCase(String text) {
 		return text.toLowerCase();
 	}
-	
+
+	@Testable
+	private String callMethodThrowingException(String example) {
+		throw new IllegalStateException(example);
+	}
 }

--- a/examples/catadioptre-java-maven-example/src/test/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExampleTest.java
+++ b/examples/catadioptre-java-maven-example/src/test/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExampleTest.java
@@ -13,4 +13,14 @@ class DefaultCatadioptreExampleTest {
 		String result = TestableDefaultCatadioptreExample.toLowerCase(instance, "T");
 		Assertions.assertThat(result).isEqualTo("t");
 	}
+
+	@Test
+	@DisplayName("should throw the same exception that the real method")
+	void shouldThrowSameExceptionRealMethod() {
+		DefaultCatadioptreExample instance = new DefaultCatadioptreExample();
+
+		Assertions.assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
+			TestableDefaultCatadioptreExample.callMethodThrowingException(instance, "test");
+		});
+	}
 }

--- a/examples/catadioptre-java-maven-example/src/test/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExampleTest.java
+++ b/examples/catadioptre-java-maven-example/src/test/java/io/aerisconsulting/catadioptre/example/DefaultCatadioptreExampleTest.java
@@ -19,8 +19,8 @@ class DefaultCatadioptreExampleTest {
 	void shouldThrowSameExceptionRealMethod() {
 		DefaultCatadioptreExample instance = new DefaultCatadioptreExample();
 
-		Assertions.assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
+		Assertions.assertThatExceptionOfType(CatadioptreExecutionException.class).isThrownBy( () -> {
 			TestableDefaultCatadioptreExample.callMethodThrowingException(instance, "test");
-		});
+		}).withCauseInstanceOf(IllegalStateException.class);
 	}
 }

--- a/examples/catadioptre-kotlin-gradle-groovy-dsl-example/src/main/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExample.kt
+++ b/examples/catadioptre-kotlin-gradle-groovy-dsl-example/src/main/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExample.kt
@@ -28,4 +28,9 @@ class PublicCatadioptreExample {
     private fun callMethodWithListInternalClass(catadioptreExample: List<CatadioptreExample>, text: String) {
         println("Calling method with generic as a type with internal visibility")
     }
+
+    @KTestable
+    private fun callMethodThrowingException(example: String) {
+        throw IllegalStateException(example)
+    }
 }

--- a/examples/catadioptre-kotlin-gradle-groovy-dsl-example/src/test/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExampleTest.kt
+++ b/examples/catadioptre-kotlin-gradle-groovy-dsl-example/src/test/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExampleTest.kt
@@ -16,7 +16,9 @@ package io.aerisconsulting.catadioptre.example
 
 import io.aerisconsulting.catadioptre.example.catadioptre.callMethodWithInternalClass
 import io.aerisconsulting.catadioptre.example.catadioptre.callMethodWithListInternalClass
+import io.aerisconsulting.catadioptre.example.catadioptre.callMethodThrowingException
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 internal class PublicCatadioptreExampleTest {
 
@@ -34,6 +36,15 @@ internal class PublicCatadioptreExampleTest {
         val instanceExample = CatadioptreExample()
 
         instance.callMethodWithListInternalClass(listOf(instanceExample), "test")
+    }
+
+    @Test
+    internal fun `should throw the same exception that the real method`() {
+        val instance = PublicCatadioptreExample()
+
+        assertThrows<IllegalStateException> {
+            instance.callMethodThrowingException("test")
+        }
     }
 
 }

--- a/examples/catadioptre-kotlin-gradle-groovy-dsl-example/src/test/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExampleTest.kt
+++ b/examples/catadioptre-kotlin-gradle-groovy-dsl-example/src/test/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExampleTest.kt
@@ -14,6 +14,9 @@
  */
 package io.aerisconsulting.catadioptre.example
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import io.aerisconsulting.catadioptre.CatadioptreOriginalCauseException
 import io.aerisconsulting.catadioptre.example.catadioptre.callMethodWithInternalClass
 import io.aerisconsulting.catadioptre.example.catadioptre.callMethodWithListInternalClass
 import io.aerisconsulting.catadioptre.example.catadioptre.callMethodThrowingException
@@ -42,9 +45,11 @@ internal class PublicCatadioptreExampleTest {
     internal fun `should throw the same exception that the real method`() {
         val instance = PublicCatadioptreExample()
 
-        assertThrows<IllegalStateException> {
+        val cause = assertThrows<CatadioptreOriginalCauseException> {
             instance.callMethodThrowingException("test")
-        }
+        }.cause
+
+        assertThat(cause?.javaClass).isEqualTo(IllegalStateException::class.java)
     }
 
 }

--- a/examples/catadioptre-kotlin-gradle-kotlin-dsl-example/src/main/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExample.kt
+++ b/examples/catadioptre-kotlin-gradle-kotlin-dsl-example/src/main/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExample.kt
@@ -28,4 +28,9 @@ class PublicCatadioptreExample {
     private fun callMethodWithListInternalClass(catadioptreExample: List<CatadioptreExample>, text: String) {
         println("Calling method with generic as a type with internal visibility")
     }
+
+    @KTestable
+    private fun callMethodThrowingException(example: String) {
+        throw IllegalStateException(example)
+    }
 }

--- a/examples/catadioptre-kotlin-gradle-kotlin-dsl-example/src/test/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExampleTest.kt
+++ b/examples/catadioptre-kotlin-gradle-kotlin-dsl-example/src/test/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExampleTest.kt
@@ -14,9 +14,11 @@
  */
 package io.aerisconsulting.catadioptre.example
 
+import io.aerisconsulting.catadioptre.example.catadioptre.callMethodThrowingException
 import io.aerisconsulting.catadioptre.example.catadioptre.callMethodWithInternalClass
 import io.aerisconsulting.catadioptre.example.catadioptre.callMethodWithListInternalClass
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 internal class PublicCatadioptreExampleTest {
 
@@ -34,5 +36,14 @@ internal class PublicCatadioptreExampleTest {
         val instanceExample = CatadioptreExample()
 
         instance.callMethodWithListInternalClass(listOf(instanceExample), "test")
+    }
+
+    @Test
+    internal fun `should throw the same exception that the real method`() {
+        val instance = PublicCatadioptreExample()
+
+        assertThrows<IllegalStateException> {
+            instance.callMethodThrowingException("test")
+        }
     }
 }

--- a/examples/catadioptre-kotlin-gradle-kotlin-dsl-example/src/test/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExampleTest.kt
+++ b/examples/catadioptre-kotlin-gradle-kotlin-dsl-example/src/test/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExampleTest.kt
@@ -14,6 +14,9 @@
  */
 package io.aerisconsulting.catadioptre.example
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import io.aerisconsulting.catadioptre.CatadioptreOriginalCauseException
 import io.aerisconsulting.catadioptre.example.catadioptre.callMethodThrowingException
 import io.aerisconsulting.catadioptre.example.catadioptre.callMethodWithInternalClass
 import io.aerisconsulting.catadioptre.example.catadioptre.callMethodWithListInternalClass
@@ -42,8 +45,10 @@ internal class PublicCatadioptreExampleTest {
     internal fun `should throw the same exception that the real method`() {
         val instance = PublicCatadioptreExample()
 
-        assertThrows<IllegalStateException> {
+        val cause = assertThrows<CatadioptreOriginalCauseException> {
             instance.callMethodThrowingException("test")
-        }
+        }.cause
+
+        assertThat(cause?.javaClass).isEqualTo(IllegalStateException::class.java)
     }
 }

--- a/examples/catadioptre-kotlin-maven-example/src/main/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExample.kt
+++ b/examples/catadioptre-kotlin-maven-example/src/main/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExample.kt
@@ -28,4 +28,9 @@ class PublicCatadioptreExample {
     private fun callMethodWithListInternalClass(catadioptreExample: List<CatadioptreExample>, text: String) {
         println("Calling method with generic as a type with internal visibility")
     }
+
+    @KTestable
+    private fun callMethodThrowingException(example: String) {
+        throw IllegalStateException(example)
+    }
 }

--- a/examples/catadioptre-kotlin-maven-example/src/test/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExampleTest.kt
+++ b/examples/catadioptre-kotlin-maven-example/src/test/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExampleTest.kt
@@ -40,8 +40,10 @@ internal class PublicCatadioptreExampleTest {
     internal fun `should throw the same exception that the real method`() {
         val instance = PublicCatadioptreExample()
 
-        assertThrows<IllegalStateException> {
+        val cause = assertThrows<CatadioptreOriginalCauseException> {
             instance.callMethodThrowingException("test")
-        }
+        }.cause
+
+        assertThat(cause?.javaClass).isEqualTo(IllegalStateException::class.java)
     }
 }

--- a/examples/catadioptre-kotlin-maven-example/src/test/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExampleTest.kt
+++ b/examples/catadioptre-kotlin-maven-example/src/test/kotlin/io/aerisconsulting/catadioptre/example/PublicCatadioptreExampleTest.kt
@@ -35,4 +35,13 @@ internal class PublicCatadioptreExampleTest {
 
         instance.callMethodWithListInternalClass(listOf(instanceExample), "test")
     }
+
+    @Test
+    internal fun `should throw the same exception that the real method`() {
+        val instance = PublicCatadioptreExample()
+
+        assertThrows<IllegalStateException> {
+            instance.callMethodThrowingException("test")
+        }
+    }
 }


### PR DESCRIPTION
- Add support for suspending function
- Add examples throwing exceptions

I am kind of divided between implementing it on Java as well, because of the checked exception.
What do you think does it makes more sense: To add almost the same behavior on Java, or to treat it differently, using a CatadioptreException that is an unchecked exception, and we tell the users to compare with the `cause` inside our custom exception?

Here in the CI, it is possible to see the problem in the Java examples ( it was the same behavior on Kotlin, before the change)